### PR TITLE
Fix `CombineInputs` eating comments

### DIFF
--- a/Studio/CelesteStudio/Editing/Document.cs
+++ b/Studio/CelesteStudio/Editing/Document.cs
@@ -602,12 +602,12 @@ public class Document {
         ChangedText(row, row);
     }
     
-    public void RemoveLines(int min, int max) {
+    public void RemoveLines(int min, int maxInclusive) {
         PushUndoState();
         
-        CurrentLines.RemoveRange(min, max - min + 1);
+        CurrentLines.RemoveRange(min, maxInclusive - min + 1);
         
-        ChangedText(min, max);
+        ChangedText(min, maxInclusive);
     }
     
     public void ReplaceRangeInLine(int row, int startCol, int endCol, string text) {

--- a/Studio/CelesteStudio/Editing/Document.cs
+++ b/Studio/CelesteStudio/Editing/Document.cs
@@ -602,12 +602,13 @@ public class Document {
         ChangedText(row, row);
     }
     
-    public void RemoveLines(int min, int maxInclusive) {
+    /// Removes an inclusive range of lines from min..max
+    public void RemoveLines(int min, int max) {
         PushUndoState();
         
-        CurrentLines.RemoveRange(min, maxInclusive - min + 1);
+        CurrentLines.RemoveRange(min, max - min + 1);
         
-        ChangedText(min, maxInclusive);
+        ChangedText(min, max);
     }
     
     public void ReplaceRangeInLine(int row, int startCol, int endCol, string text) {

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2006,8 +2006,20 @@ public sealed class Editor : Drawable {
             int activeRowStart = -1;
             
             for (int row = minRow; row <= maxRow; row++) {
-                if (!TryParseAndFormatActionLine(row, out var currActionLine))
+                if (!TryParseAndFormatActionLine(row, out var currActionLine)) {
+                    // "Flush" the remaining line
+                    if (activeActionLine != null) {
+                        Document.RemoveLines(activeRowStart, row-1);
+                        Document.InsertLine(activeRowStart, activeActionLine.Value.ToString());
+
+                        maxRow -= (row-1 - activeRowStart);
+                        row = activeRowStart + 1;
+
+                        activeActionLine = null;
+                        activeRowStart = -1;
+                    }
                     continue; // Skip non-input lines
+                }
                 
                 if (activeActionLine == null) {
                     activeActionLine = currActionLine;

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2007,12 +2007,12 @@ public sealed class Editor : Drawable {
             
             for (int row = minRow; row <= maxRow; row++) {
                 if (!TryParseAndFormatActionLine(row, out var currActionLine)) {
-                    // "Flush" the remaining line
+                    // "Flush" the previous lines
                     if (activeActionLine != null) {
-                        Document.RemoveLines(activeRowStart, row-1);
+                        Document.RemoveLines(activeRowStart, row - 1);
                         Document.InsertLine(activeRowStart, activeActionLine.Value.ToString());
 
-                        maxRow -= (row-1 - activeRowStart);
+                        maxRow -= row - 1 - activeRowStart;
                         row = activeRowStart + 1;
 
                         activeActionLine = null;


### PR DESCRIPTION
When all of
```
  1,L
#lvl_abc
  1,L
```
is selected, combining inputs would result in
```
  2,L
```


Now it keeps the input untouched, just merging inputs before and after the comment.