### PR TITLE
make delete at end of line work

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -1471,16 +1471,34 @@ public sealed class Editor : Drawable {
                     line = actionLine.ToString();
                     goto FinishDeletion;
                 } else if (caret.Col == featherColumn && direction is CaretMovementType.CharRight or CaretMovementType.WordRight ||
-                           caret.Col == angleMagnitudeCommaColumn && direction is CaretMovementType.CharLeft or CaretMovementType.WordLeft) {
+                           caret.Col == angleMagnitudeCommaColumn && direction is CaretMovementType.CharLeft or CaretMovementType.WordLeft) 
+                {
                     actionLine.FeatherAngle = actionLine.FeatherMagnitude;
                     actionLine.FeatherMagnitude = null;
                     caret.Col = featherColumn;
                     line = actionLine.ToString();
                     goto FinishDeletion;
                 } else if (caret.Col == angleMagnitudeCommaColumn - 1 &&
-                           direction is CaretMovementType.CharRight or CaretMovementType.WordRight) {
+                           direction is CaretMovementType.CharRight or CaretMovementType.WordRight) 
+                {
                     actionLine.FeatherMagnitude = null;
                     line = actionLine.ToString();
+                    goto FinishDeletion;
+                }
+            }
+            
+            // Remove blank lines with delete at the end of a line
+            if (caret.Col == line.Length &&
+                caret.Row < Document.Lines.Count - 1 && 
+                string.IsNullOrWhiteSpace(Document.Lines[caret.Row + 1])) 
+            {
+                if (direction == CaretMovementType.CharRight) {
+                    Document.RemoveLine(caret.Row + 1);
+                    goto FinishDeletion;
+                } else if (direction == CaretMovementType.WordRight) {
+                    while (caret.Row < Document.Lines.Count - 1 && string.IsNullOrWhiteSpace(Document.Lines[caret.Row + 1])) {
+                        Document.RemoveLine(caret.Row + 1);
+                    }
                     goto FinishDeletion;
                 }
             }
@@ -1493,13 +1511,6 @@ public sealed class Editor : Drawable {
                 _ => caret.Col,
             };
 
-            if (newColumn == line.Length && Document.Lines.Count > caret.Row) {
-                var nextLine = Document.Lines[caret.Row + 1];
-                if (nextLine.AsSpan().Trim().Length == 0) {
-                    Document.RemoveLine(caret.Row + 1);
-                }
-            }
-            
             line = line.Remove(Math.Min(newColumn, caret.Col), Math.Abs(newColumn - caret.Col));
             caret.Col = Math.Min(newColumn, caret.Col);
             

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -1492,6 +1492,13 @@ public sealed class Editor : Drawable {
                 CaretMovementType.WordRight => GetHardSnapColumns(actionLine).FirstOrDefault(c => c > caret.Col, caret.Col),
                 _ => caret.Col,
             };
+
+            if (newColumn == line.Length && Document.Lines.Count > caret.Row) {
+                var nextLine = Document.Lines[caret.Row + 1];
+                if (nextLine.AsSpan().Trim().Length == 0) {
+                    Document.RemoveLine(caret.Row + 1);
+                }
+            }
             
             line = line.Remove(Math.Min(newColumn, caret.Col), Math.Abs(newColumn - caret.Col));
             caret.Col = Math.Min(newColumn, caret.Col);


### PR DESCRIPTION
When the document looks like
```c
   14,D,R,X<|>

   8,J
```

and I press delete, I would expect the line after me to be deleted.

For 
```c
   14,D,R,X<|>
   8,J
```
, nothing happens as before.