### PR TITLE
add bindings for some game hotkeys

### DIFF
--- a/Studio/CelesteStudio/Communication/CommunicationWrapper.cs
+++ b/Studio/CelesteStudio/Communication/CommunicationWrapper.cs
@@ -63,6 +63,13 @@ public static class CommunicationWrapper {
             comm!.SendPath(path);
         }
     }
+
+    public static void SendHotkey(HotkeyID hotkey) {
+        if (Connected) {
+            comm!.SendHotkey(hotkey, false);
+        }
+    }
+
     public static bool SendKeyEvent(Keys key, Keys modifiers, bool released) {
         var winFormsKey = key.ToWinForms();
         

--- a/Studio/CelesteStudio/Data/MenuEntry.cs
+++ b/Studio/CelesteStudio/Data/MenuEntry.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using CelesteStudio.Util;
 using Eto.Forms;
 
@@ -27,8 +26,10 @@ public enum MenuEntry {
     Status_EditCustomInfoTemplate, Status_ClearWatchEntityInfo,
     
     StatusPopout_AlwaysOnTop,
+    
+    Game_Start, Game_Restart, Game_FrameAdvance, Game_Pause,
 }
-public enum MenuEntryCategory { File, Settings, View, Editor, Status, StatusPopout }
+public enum MenuEntryCategory { File, Settings, View, Editor, Status, StatusPopout, GameHotkeys }
 
 public static class MenuEntryExtensions {
     private static readonly Dictionary<MenuEntry, Keys> DefaultKeyBindings = new() {
@@ -86,6 +87,11 @@ public static class MenuEntryExtensions {
         { MenuEntry.Status_ClearWatchEntityInfo, Keys.None },
         
         { MenuEntry.StatusPopout_AlwaysOnTop, Keys.None },
+        
+        { MenuEntry.Game_Start, Keys.None },
+        { MenuEntry.Game_Pause, Keys.Equal },
+        { MenuEntry.Game_Restart, Keys.Semicolon },
+        { MenuEntry.Game_FrameAdvance, Keys.Backslash },
     };
     private static readonly Dictionary<MenuEntry, string> EntryNames = new() {
         { MenuEntry.File_New, "&New File" },
@@ -142,6 +148,11 @@ public static class MenuEntryExtensions {
         { MenuEntry.Status_ClearWatchEntityInfo, "Clear Watch Entity Info" },
         
         { MenuEntry.StatusPopout_AlwaysOnTop, "Always on Top" },
+        
+        { MenuEntry.Game_Start, "Start" },
+        { MenuEntry.Game_Pause, "Pause" },
+        { MenuEntry.Game_Restart, "Restart" },
+        { MenuEntry.Game_FrameAdvance, "Advance Frame" },
     };
     private static readonly Dictionary<MenuEntryCategory, MenuEntry[]> Categories = new() {
         { MenuEntryCategory.File, [
@@ -169,6 +180,8 @@ public static class MenuEntryExtensions {
             MenuEntry.Status_EditCustomInfoTemplate, MenuEntry.Status_ClearWatchEntityInfo] },
 
         { MenuEntryCategory.StatusPopout, [MenuEntry.StatusPopout_AlwaysOnTop] },
+        
+        { MenuEntryCategory.GameHotkeys, [MenuEntry.Game_Start, MenuEntry.Game_Pause, MenuEntry.Game_Restart, MenuEntry.Game_FrameAdvance] },
     };
     
 #if DEBUG
@@ -204,6 +217,7 @@ public static class MenuEntryExtensions {
         MenuEntryCategory.Editor => "Editor - Context Menu",
         MenuEntryCategory.Status => "Status - Context Menu",
         MenuEntryCategory.StatusPopout => "Status Popout - Context Menu",
+        MenuEntryCategory.GameHotkeys => "Game Hotkeys",
         _ => throw new UnreachableException(),
     };
     

--- a/Studio/CelesteStudio/Data/MenuEntry.cs
+++ b/Studio/CelesteStudio/Data/MenuEntry.cs
@@ -89,9 +89,9 @@ public static class MenuEntryExtensions {
         { MenuEntry.StatusPopout_AlwaysOnTop, Keys.None },
         
         { MenuEntry.Game_Start, Keys.None },
-        { MenuEntry.Game_Pause, Keys.Equal },
-        { MenuEntry.Game_Restart, Keys.Semicolon },
-        { MenuEntry.Game_FrameAdvance, Keys.Backslash },
+        { MenuEntry.Game_Pause, Keys.None },
+        { MenuEntry.Game_Restart, Keys.None },
+        { MenuEntry.Game_FrameAdvance, Keys.None },
     };
     private static readonly Dictionary<MenuEntry, string> EntryNames = new() {
         { MenuEntry.File_New, "&New File" },

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -802,10 +802,11 @@ public sealed class Editor : Drawable {
                 break;
             default:
                 if (e.Key != Keys.None) {
-                    // Search through context menu for hotkeys
+                    // Check for hotkeys
                     var items = ContextMenu.Items
                         .Concat(Studio.Instance.GameInfoPanel.ContextMenu.Items)
-                        .Concat(Studio.Instance.Menu.Items);
+                        .Concat(Studio.Instance.Menu.Items)
+                        .Concat(Studio.Instance.GlobalHotkeys);
                     foreach (var item in items) {
                         if (item.Shortcut != e.KeyData) {
                             continue;

--- a/Studio/CelesteStudio/Studio.cs
+++ b/Studio/CelesteStudio/Studio.cs
@@ -14,6 +14,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using FontDialog = CelesteStudio.Dialog.FontDialog;
 using Eto.Forms.ThemedControls;
+using StudioCommunication;
 
 namespace CelesteStudio;
 
@@ -464,6 +465,12 @@ public sealed class Studio : Form {
                     featherlineForm.Show();
                     featherlineForm.Closed += (_, _) => featherlineForm = null;
                 }),
+            }},
+            new SubMenuItem { Visible = false, Text = "&Game Hotkeys", Items = {
+                MenuEntry.Game_Start.ToAction(() => CommunicationWrapper.SendHotkey(HotkeyID.Start)),
+                MenuEntry.Game_Pause.ToAction(() => CommunicationWrapper.SendHotkey(HotkeyID.Pause)),
+                MenuEntry.Game_Restart.ToAction(() => CommunicationWrapper.SendHotkey(HotkeyID.Restart)),
+                MenuEntry.Game_FrameAdvance.ToAction(() => CommunicationWrapper.SendHotkey(HotkeyID.FrameAdvance)),
             }},
         ];
         


### PR DESCRIPTION
Celeste and Studio don't necessarily agree which bindings map to which keys.
By allowing to override common actions like Start, Restart, Pause, I can set my preferred keybinds in studio.