### PR TITLE
Add feature to peform simple calculations on the frame number

### DIFF
--- a/Studio/CelesteStudio/Editing/CalculationState.cs
+++ b/Studio/CelesteStudio/Editing/CalculationState.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+using CelesteStudio.Util;
+
+namespace CelesteStudio.Editing;
+
+public class CalculationState(CalculationOperator op, int row) {
+    public readonly CalculationOperator Operator = op;
+    public readonly int Row = row;
+
+    public string Operand = string.Empty;
+}
+
+public enum CalculationOperator {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+public static class CalculationExtensions {
+    public static CalculationOperator? TryParse(char c) {
+        return c switch {
+            '+' => CalculationOperator.Add,
+            '-' => CalculationOperator.Sub,
+            '*' => CalculationOperator.Mul,
+            '/' => CalculationOperator.Div,
+            _ => null
+        };
+    }
+    public static char Char(this CalculationOperator op) {
+        return op switch {
+            CalculationOperator.Add => '+',
+            CalculationOperator.Sub => '-',
+            CalculationOperator.Mul => '*',
+            CalculationOperator.Div => '/',
+            _ => throw new UnreachableException(),
+        };
+    }
+    
+    public static CalculationOperator Inverse(this CalculationOperator op) {
+        return op switch {
+            CalculationOperator.Add => CalculationOperator.Sub,
+            CalculationOperator.Sub => CalculationOperator.Add,
+            CalculationOperator.Mul => CalculationOperator.Div,
+            CalculationOperator.Div => CalculationOperator.Mul,
+            _ => throw new UnreachableException(),
+        };
+    }
+
+    public static int Apply(this CalculationOperator op, int value, int operand) {
+        return op switch {
+            CalculationOperator.Add => value + operand,
+            CalculationOperator.Sub => value - operand,
+            CalculationOperator.Mul => value * operand,
+            CalculationOperator.Div => value / operand,
+            _ => throw new UnreachableException(),
+        };
+    }
+    public static ActionLine Apply(this CalculationOperator op, ActionLine actionLine, int operand) {
+        return actionLine with { Frames = op.Apply(actionLine.Frames, operand) };
+    }
+}

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -1882,6 +1882,12 @@ public sealed class Editor : Drawable {
             state.Operand += num;
             e.Handled = true;
         } else if (CalculateOpMethods.TryParse(e.KeyChar) is {} op) {
+            if (op == state.Op && state.Operand.Length == 0) {
+                calculateState = null;
+                e.Handled = true;
+                return;
+            }
+                
             CommitCalculate(state);
             OnCalculateModeEnter(op);
             e.Handled = true;

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -27,6 +27,16 @@ internal enum CalculateOp {
 }
 
 internal static class CalculateOpMethods {
+    public static CalculateOp? TryParse(char c) {
+        return c switch {
+            '+' => CalculateOp.Add,
+            '-' => CalculateOp.Sub,
+            '*' => CalculateOp.Mul,
+            '/' => CalculateOp.Div,
+            _ => null
+        };
+    }
+
     public static CalculateOp Inverse(this CalculateOp op) {
         return op switch {
             CalculateOp.Add => CalculateOp.Sub,
@@ -860,17 +870,8 @@ public sealed class Editor : Drawable {
                 e.Handled = true;
                 break;
             default:
-                if (e.KeyChar == '+') {
-                    OnCalculateModeEnter(CalculateOp.Add);
-                    e.Handled = true;
-                } else if (e.KeyChar == '-') {
-                    OnCalculateModeEnter(CalculateOp.Sub);
-                    e.Handled = true;
-                } else if (e.KeyChar == '*') {
-                    OnCalculateModeEnter(CalculateOp.Mul);
-                    e.Handled = true;
-                } else if (e.KeyChar == '/') {
-                    OnCalculateModeEnter(CalculateOp.Div);
+                if (CalculateOpMethods.TryParse(e.KeyChar) is { } op) {
+                    OnCalculateModeEnter(op);
                     e.Handled = true;
                 } else if (e.Key != Keys.None) {
                     // Search through context menu for hotkeys
@@ -1941,21 +1942,9 @@ public sealed class Editor : Drawable {
             var num = e.Key - Keys.D0;
             state.Operand += num;
             e.Handled = true;
-        } else if (e.KeyChar == '+') {
+        } else if (CalculateOpMethods.TryParse(e.KeyChar) is {} op) {
             CommitCalculate(state);
-            OnCalculateModeEnter(CalculateOp.Add);
-            e.Handled = true;
-        } else if (e.KeyChar == '-') {
-            CommitCalculate(state);
-            OnCalculateModeEnter(CalculateOp.Sub);
-            e.Handled = true;
-        } else if (e.KeyChar == '*') {
-            CommitCalculate(state);
-            OnCalculateModeEnter(CalculateOp.Mul);
-            e.Handled = true;
-        } else if (e.KeyChar == '/') {
-            CommitCalculate(state);
-            OnCalculateModeEnter(CalculateOp.Div);
+            OnCalculateModeEnter(op);
             e.Handled = true;
         } else {
             if (e.Key is >= Keys.A and <= Keys.Z) {

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -19,67 +19,6 @@ using WrapEntry = (int StartOffset, (string Line, int Index)[] Lines);
 
 namespace CelesteStudio.Editing;
 
-internal enum CalculateOp {
-    Add,
-    Sub,
-    Mul,
-    Div,
-}
-
-internal static class CalculateOpMethods {
-    public static CalculateOp? TryParse(char c) {
-        return c switch {
-            '+' => CalculateOp.Add,
-            '-' => CalculateOp.Sub,
-            '*' => CalculateOp.Mul,
-            '/' => CalculateOp.Div,
-            _ => null
-        };
-    }
-
-    public static CalculateOp Inverse(this CalculateOp op) {
-        return op switch {
-            CalculateOp.Add => CalculateOp.Sub,
-            CalculateOp.Sub => CalculateOp.Add,
-            CalculateOp.Mul => CalculateOp.Div,
-            CalculateOp.Div => CalculateOp.Mul,
-            _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
-        };
-    }
-
-    private static int Apply(this CalculateOp op, int value, int operand) {
-        return op switch {
-            CalculateOp.Add => value + operand,
-            CalculateOp.Sub => value - operand,
-            CalculateOp.Mul => value * operand,
-            CalculateOp.Div => value / operand,
-            _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
-        };
-    }
-    
-    public static ActionLine Apply(this CalculateOp op, ActionLine actionLine, int operand) {
-        int newFrames = op.Apply(actionLine.Frames, operand);
-        return actionLine with { Frames = Math.Clamp(newFrames, 0, ActionLine.MaxFrames) };
-    }
-
-    public static char Char(this CalculateOp op) {
-        return op switch {
-            CalculateOp.Add => '+',
-            CalculateOp.Sub => '-',
-            CalculateOp.Mul => '*',
-            CalculateOp.Div => '/',
-            _ => throw new ArgumentOutOfRangeException()
-        };
-    }
-}
-
-internal class CalculateState(CalculateOp op, string operand, int row, ActionLine actionLine) {
-    public CalculateOp Op = op;
-    public string Operand = operand;
-    public int Row = row;
-    public ActionLine ActionLine = actionLine;
-}
-
 public sealed class Editor : Drawable {
     private Document? document;
     public Document Document {
@@ -3155,4 +3094,65 @@ public sealed class Editor : Drawable {
     }
     
     #endregion
+}
+
+internal enum CalculateOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+internal static class CalculateOpMethods {
+    public static CalculateOp? TryParse(char c) {
+        return c switch {
+            '+' => CalculateOp.Add,
+            '-' => CalculateOp.Sub,
+            '*' => CalculateOp.Mul,
+            '/' => CalculateOp.Div,
+            _ => null
+        };
+    }
+
+    public static CalculateOp Inverse(this CalculateOp op) {
+        return op switch {
+            CalculateOp.Add => CalculateOp.Sub,
+            CalculateOp.Sub => CalculateOp.Add,
+            CalculateOp.Mul => CalculateOp.Div,
+            CalculateOp.Div => CalculateOp.Mul,
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
+        };
+    }
+
+    private static int Apply(this CalculateOp op, int value, int operand) {
+        return op switch {
+            CalculateOp.Add => value + operand,
+            CalculateOp.Sub => value - operand,
+            CalculateOp.Mul => value * operand,
+            CalculateOp.Div => value / operand,
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
+        };
+    }
+    
+    public static ActionLine Apply(this CalculateOp op, ActionLine actionLine, int operand) {
+        int newFrames = op.Apply(actionLine.Frames, operand);
+        return actionLine with { Frames = Math.Clamp(newFrames, 0, ActionLine.MaxFrames) };
+    }
+
+    public static char Char(this CalculateOp op) {
+        return op switch {
+            CalculateOp.Add => '+',
+            CalculateOp.Sub => '-',
+            CalculateOp.Mul => '*',
+            CalculateOp.Div => '/',
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}
+
+internal class CalculateState(CalculateOp op, string operand, int row, ActionLine actionLine) {
+    public CalculateOp Op = op;
+    public string Operand = operand;
+    public int Row = row;
+    public ActionLine ActionLine = actionLine;
 }

--- a/Studio/CelesteStudio/Editing/Theme.cs
+++ b/Studio/CelesteStudio/Editing/Theme.cs
@@ -23,6 +23,8 @@ public struct Theme {
     public Color ServiceLine;
     public Color StatusFg;
     public Color StatusBg;
+    public Color CalculateFg;
+    public Color CalculateBg;
     public Color AutoCompleteFg;
     public Color AutoCompleteFgExtra;
     public Color AutoCompleteBg;
@@ -62,6 +64,8 @@ public struct Theme {
             ServiceLine = Color.FromRgb(0xC6C6C6),
             StatusFg = Color.FromRgb(0x0F0F0F),
             StatusBg = Color.FromRgb(0xE1E1E1),
+            CalculateFg = Color.FromRgb(0xCBCBCB),
+            CalculateBg = Color.FromRgb(0x6C6C6C),
             AutoCompleteFg = Color.FromRgb(0x121212),
             AutoCompleteFgExtra = Color.FromRgb(0x595959),
             AutoCompleteBg = Color.FromRgb(0xD3D3D3),
@@ -97,6 +101,8 @@ public struct Theme {
             ServiceLine = Color.FromRgb(0x4E4E4E),
             StatusFg = Color.FromRgb(0xF8F8F8),
             StatusBg = Color.FromRgb(0x303030),
+            CalculateFg = Color.FromRgb(0xE8E8E8),
+            CalculateBg = Color.FromRgb(0x4682B4),
             AutoCompleteFg = Color.FromRgb(0xDFDFDF),
             AutoCompleteFgExtra = Color.FromRgb(0x9F9F9F),
             AutoCompleteBg = Color.FromRgb(0x2C2C2C),
@@ -133,6 +139,8 @@ public struct Theme {
             ServiceLine = Color.FromRgb(0xC0C0C0),
             StatusFg = Color.FromRgb(0x000000),
             StatusBg = Color.FromRgb(0xF2F2F2),
+            CalculateFg = Color.FromRgb(0xCBCBCB),
+            CalculateBg = Color.FromRgb(0x6C6C6C),
             AutoCompleteFg = Color.FromRgb(0x121212),
             AutoCompleteFgExtra = Color.FromRgb(0x646464),
             AutoCompleteBg = Color.FromRgb(0xE9E9E9),
@@ -168,6 +176,8 @@ public struct Theme {
             ServiceLine = Color.FromRgb(0x44475A),
             StatusFg = Color.FromRgb(0xF8F8F2),
             StatusBg = Color.FromRgb(0x383A46),
+            CalculateFg = Color.FromRgb(0xE8E8E8),
+            CalculateBg = Color.FromRgb(0x4682B4),
             AutoCompleteFg = Color.FromRgb(0xDFDFDF),
             AutoCompleteFgExtra = Color.FromRgb(0x9F9F9F),
             AutoCompleteBg = Color.FromRgb(0x2F303B),


### PR DESCRIPTION
When you press `+ - * /` while on an action line, it lets you perform a calculation on the frame number:

https://github.com/user-attachments/assets/9f106c68-5ee4-4333-bc96-71fa782b0256


I also added the feature to "steal" frames from the line below or above, i.e. when you press `+5 ↓` you add 5 frames to the current line, and subtract 5 from the next one.

https://github.com/user-attachments/assets/6747b3f2-3a1b-4baa-a837-1b76c7fb13df

