### PR TITLE
reread file when opening current path

### DIFF
--- a/Studio/CelesteStudio/Studio.cs
+++ b/Studio/CelesteStudio/Studio.cs
@@ -231,10 +231,6 @@ public sealed class Studio : Form {
     }
     
     public void OpenFile(string filePath) {
-        if (filePath == Editor.Document.FilePath && filePath != Document.ScratchFile) {
-            return;
-        }
-        
         if (!string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath))
             Settings.Instance.AddRecentFile(filePath);
         


### PR DESCRIPTION
When I open a file I expect it to have up to date contents, so the file reading shouldn't be skipped just because the file is the same.
