### PR TITLE
fix first selection line rendering width

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2901,10 +2901,10 @@ public sealed class Editor : Drawable {
                 e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w, h);
             } else {
                 var visualLine = GetVisualLine(min.Row);
-                float x = Font.CharWidth() * min.Col + textOffsetX;
+                float x = Font.CharWidth() * min.Col + textOffsetX - LineNumberPadding;
                 float w = visualLine.Length == 0 ? 0.0f : Font.MeasureWidth(visualLine[min.Col..]);
                 float y = Font.LineHeight() * min.Row;
-                e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w, Font.LineHeight());
+                e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w + LineNumberPadding, Font.LineHeight());
                 
                 // Cull off-screen lines
                 for (int i = Math.Max(min.Row + 1, topVisualRow); i < Math.Min(max.Row, bottomVisualRow); i++) {

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2901,10 +2901,13 @@ public sealed class Editor : Drawable {
                 e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w, h);
             } else {
                 var visualLine = GetVisualLine(min.Row);
-                float x = Font.CharWidth() * min.Col + textOffsetX - LineNumberPadding;
+                
+                // When the selection starts at the beginning of the line, extend it to cover the LineNumberPadding as well
+                float extendLeft = min.Col == 0 ? LineNumberPadding : 0.0f;
+                float x = Font.CharWidth() * min.Col + textOffsetX - extendLeft;
                 float w = visualLine.Length == 0 ? 0.0f : Font.MeasureWidth(visualLine[min.Col..]);
                 float y = Font.LineHeight() * min.Row;
-                e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w + LineNumberPadding, Font.LineHeight());
+                e.Graphics.FillRectangle(Settings.Instance.Theme.Selection, x, y, w + extendLeft, Font.LineHeight());
                 
                 // Cull off-screen lines
                 for (int i = Math.Max(min.Row + 1, topVisualRow); i < Math.Min(max.Row, bottomVisualRow); i++) {


### PR DESCRIPTION
I think these got missed in https://github.com/psygamer/CelesteTAS-EverestInterop-MonoFix/commit/38592793cbdfec26b57dfa7f35aee178aa87f490

![image](https://github.com/user-attachments/assets/f1e27a20-dc3d-4f08-b06c-4e2ab6ec2a6a)
