### PR TITLE
snap to frame count when moving to an action line

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2368,7 +2368,8 @@ public sealed class Editor : Drawable {
         var line = Document.Lines[Document.Caret.Row];
         var oldCaret = Document.Caret;
         
-        if (ActionLine.TryParse(line, out var actionLine)) {
+        ActionLine? currentActionLine = ActionLine.Parse(line);
+        if (currentActionLine is {} actionLine) {
             Document.Caret.Col = Math.Min(line.Length, SnapColumnToActionLine(actionLine, Document.Caret.Col));
             int leadingSpaces = ActionLine.MaxFramesDigits - actionLine.Frames.Digits();
             
@@ -2404,6 +2405,10 @@ public sealed class Editor : Drawable {
         var oldVisualPos = GetVisualPosition(oldCaret);
         var newVisualPos = GetVisualPosition(Document.Caret);
         if (oldCaret.Row != Document.Caret.Row) {
+            if (currentActionLine == null && ActionLine.TryParse(Document.Lines[Document.Caret.Row], out _)) {
+                desiredVisualCol = ActionLine.MaxFramesDigits;
+            }
+            
             newVisualPos.Col = desiredVisualCol;
         } else {
             desiredVisualCol = newVisualPos.Col;

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2402,18 +2402,18 @@ public sealed class Editor : Drawable {
         }
         
         // Apply / Update desired column
-        var oldVisualPos = GetVisualPosition(oldCaret);
         var newVisualPos = GetVisualPosition(Document.Caret);
         if (oldCaret.Row != Document.Caret.Row) {
-            if (currentActionLine == null && ActionLine.TryParse(Document.Lines[Document.Caret.Row], out _)) {
-                desiredVisualCol = ActionLine.MaxFramesDigits;
-            }
-            
             newVisualPos.Col = desiredVisualCol;
         } else {
             desiredVisualCol = newVisualPos.Col;
         }
         Document.Caret = ClampCaret(GetActualPosition(newVisualPos));
+        
+        // When going from a non-action-line to an action-line, snap the caret to the frame count
+        if (currentActionLine == null && TryParseAndFormatActionLine(Document.Caret.Row, out _)) {
+            Document.Caret.Col = desiredVisualCol = ActionLine.MaxFramesDigits;
+        }
         
         if (updateSelection) {
             if (Document.Selection.Empty) {


### PR DESCRIPTION
If my cursor is here:
```hs
#Start
   1,R,K
  14,R,D,X
   1,L,J
   7,F,239
  10,F,300
  74,R,J
<|>
```
and I move up, my muscle memory has come to expect that I can immediately start editing the 74 from the right.