### PR TITLE
only snap to frame count if movement is LineUp or LineDown

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2483,7 +2483,7 @@ public sealed class Editor : Drawable {
         Document.Caret = ClampCaret(GetActualPosition(newVisualPos));
         
         // When going from a non-action-line to an action-line, snap the caret to the frame count
-        if (currentActionLine == null && TryParseAndFormatActionLine(Document.Caret.Row, out _)) {
+        if (direction is CaretMovementType.LineUp or CaretMovementType.LineDown && currentActionLine == null && TryParseAndFormatActionLine(Document.Caret.Row, out _)) {
             Document.Caret.Col = desiredVisualCol = ActionLine.MaxFramesDigits;
         }
         

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2483,7 +2483,9 @@ public sealed class Editor : Drawable {
         Document.Caret = ClampCaret(GetActualPosition(newVisualPos));
         
         // When going from a non-action-line to an action-line, snap the caret to the frame count
-        if (direction is CaretMovementType.LineUp or CaretMovementType.LineDown && currentActionLine == null && TryParseAndFormatActionLine(Document.Caret.Row, out _)) {
+        if (direction is CaretMovementType.LineUp or CaretMovementType.LineDown or CaretMovementType.PageUp or CaretMovementType.PageDown or CaretMovementType.LabelUp or CaretMovementType.LabelDown && 
+            currentActionLine == null && TryParseAndFormatActionLine(Document.Caret.Row, out _)) 
+        {
             Document.Caret.Col = desiredVisualCol = ActionLine.MaxFramesDigits;
         }
         


### PR DESCRIPTION
fix after #14 


```hs
  100,J,PQ,F,90
<|>
```
when moving left I want to edit the 90.