### PR TITLE
Only suggest context actions when applicable

### DIFF
--- a/Studio/CelesteStudio/Editing/ContextActions/SplitFrames.cs
+++ b/Studio/CelesteStudio/Editing/ContextActions/SplitFrames.cs
@@ -13,7 +13,7 @@ public class SplitFrames : ContextAction {
         
         bool valid = false;
         for (int row = minRow; row <= maxRow; row++) {
-            if (!ActionLine.TryParse(Document.Lines[row], out var actionLine) || actionLine.Frames == 0) {
+            if (!ActionLine.TryParse(Document.Lines[row], out var actionLine) || actionLine.Frames <= 1) {
                 continue;
             }
             

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -153,11 +153,12 @@ public sealed class Editor : Drawable {
 
     // These should be ordered from most specific to most applicable.
     private readonly ContextAction[] contextActions = [
+        new CombineConsecutiveSameInputs(),
+        
         new SwapActions(Actions.Left, Actions.Right, MenuEntry.Editor_SwapSelectedLR),
         new SwapActions(Actions.Jump, Actions.Jump2, MenuEntry.Editor_SwapSelectedJK),
         new SwapActions(Actions.Dash, Actions.Dash2, MenuEntry.Editor_SwapSelectedXC),
 
-        new CombineConsecutiveSameInputs(),
         new ForceCombineInputFrames(),
         new SplitFrames(),
 


### PR DESCRIPTION
- `   1,K` should not suggest splitting up frames
- Combining consecutive inputs should only be suggested if there are actual changes to combine. 
  - This is fixed by checking `CombineInputs` in a dry-run mode when checking whether there are changes to be done. The performance hit is negligible, <1ms.
- Now that it only shows up when expected, prioritize combining consecutive inputs over the swap actions. It's more likely to be what you want when you press `Alt+Enter Enter`.