### PR TITLE
Fix crashes from inserting savestate or current time when there is a selection

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2143,6 +2143,16 @@ public sealed class Editor : Drawable {
 
         int insertDir = Settings.Instance.InsertDirection == InsertDirection.Above ? -1 : 1;
 
+        if (!Document.Selection.Empty) {
+            CaretPosition collapseToRow = Settings.Instance.InsertDirection switch {
+                InsertDirection.Above => Document.Selection.Min,
+                InsertDirection.Below => Document.Selection.Max,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+            Document.Selection.Clear();
+            Document.Caret = collapseToRow;
+        }
+
         // Check current line
         if (regex.IsMatch(Document.Lines[Document.Caret.Row])) {
             Document.RemoveLine(Document.Caret.Row);

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2121,7 +2121,7 @@ public sealed class Editor : Drawable {
         using var __ = Document.Update();
 
         CollapseSelection();
-        
+
         if (Settings.Instance.InsertDirection == InsertDirection.Above) {
             Document.InsertLineAbove(text);
 
@@ -2144,7 +2144,7 @@ public sealed class Editor : Drawable {
         using var __ = Document.Update();
 
         CollapseSelection();
-        
+
         int insertDir = Settings.Instance.InsertDirection == InsertDirection.Above ? -1 : 1;
 
         // Check current line

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2141,17 +2141,9 @@ public sealed class Editor : Drawable {
     private void InsertOrRemoveText(Regex regex, string text) {
         using var __ = Document.Update();
 
+        CollapseSelection();
+        
         int insertDir = Settings.Instance.InsertDirection == InsertDirection.Above ? -1 : 1;
-
-        if (!Document.Selection.Empty) {
-            CaretPosition collapseToRow = Settings.Instance.InsertDirection switch {
-                InsertDirection.Above => Document.Selection.Min,
-                InsertDirection.Below => Document.Selection.Max,
-                _ => throw new ArgumentOutOfRangeException()
-            };
-            Document.Selection.Clear();
-            Document.Caret = collapseToRow;
-        }
 
         // Check current line
         if (regex.IsMatch(Document.Lines[Document.Caret.Row])) {
@@ -2450,6 +2442,18 @@ public sealed class Editor : Drawable {
             return line.Length >= 2 && line[0] == '#' && char.IsLetter(line[1]) ||
                    line.TrimStart().StartsWith("***");
         }
+    }
+    
+    void CollapseSelection() {
+        if (Document.Selection.Empty) return;
+        
+        var collapseToRow = Settings.Instance.InsertDirection switch {
+            InsertDirection.Above => Document.Selection.Min,
+            InsertDirection.Below => Document.Selection.Max,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        Document.Selection.Clear();
+        Document.Caret = collapseToRow;
     }
 
     #endregion

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2120,6 +2120,8 @@ public sealed class Editor : Drawable {
     private void InsertLine(string text) {
         using var __ = Document.Update();
 
+        CollapseSelection();
+        
         if (Settings.Instance.InsertDirection == InsertDirection.Above) {
             Document.InsertLineAbove(text);
 


### PR DESCRIPTION
The fix is to collapse selection to the start or end, respecting the `InsertDirection`.