### PR TITLE
open file after Studio form is initialized to fix deadlock

### DIFF
--- a/Studio/CelesteStudio/Studio.cs
+++ b/Studio/CelesteStudio/Studio.cs
@@ -127,7 +127,7 @@ public sealed class Studio : Form {
             });
         }
 
-        Shown += (_, _) => {
+        Load += (_, _) => {
             if (args.Length > 0) {
                 OpenFile(args[0]);
             } else if (Settings.Instance.RecentFiles.Count > 0 &&

--- a/Studio/CelesteStudio/Studio.cs
+++ b/Studio/CelesteStudio/Studio.cs
@@ -125,16 +125,20 @@ public sealed class Studio : Form {
                 CommandInfo.ResetCache();
                 Menu = CreateMenu();
             });
+        }
 
+        Shown += (_, _) => {
             if (args.Length > 0) {
                 OpenFile(args[0]);
-            } else if (Settings.Instance.RecentFiles.Count > 0 && !string.IsNullOrWhiteSpace(Settings.Instance.RecentFiles[0]) && File.Exists(Settings.Instance.RecentFiles[0])) {
+            } else if (Settings.Instance.RecentFiles.Count > 0 &&
+                       !string.IsNullOrWhiteSpace(Settings.Instance.RecentFiles[0]) &&
+                       File.Exists(Settings.Instance.RecentFiles[0])) {
                 // Re-open last file if possible
                 OpenFile(Settings.Instance.RecentFiles[0]);
             } else {
                 OnNewFile();
             }
-        }
+        };
 
         // var asm = Assembly.GetExecutingAssembly();
         // Shown += (_, _) => WhatsNewDialog.Show("Whats new in Studio v3.0.0?", new StreamReader(asm.GetManifestResourceStream("Changelogs/v3.0.0.md")!).ReadToEnd());


### PR DESCRIPTION
the deadlock happened when opening an empty file in a chain of `Studio constructor -> OpenFile -> load document -> insert line 0 if empty -> OnTextChanged -> UpdateGameInfo -> Application.Instance.Invoke`. 