### PR TITLE
toggle inputs: ignore room label and timestamp lines

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2086,8 +2086,13 @@ public sealed class Editor : Drawable {
 
         for (int row = minRow; row <= maxRow; row++) {
             var line = Document.Lines[row];
+            var lineTrimmed = line.TrimStart();
 
-            if (line.TrimStart().StartsWith('#')) {
+            if (lineTrimmed.StartsWith('#')) {
+                if (lineTrimmed.StartsWith("#lvl_") || TimestampRegex.IsMatch(lineTrimmed)) {
+                    continue;
+                }
+
                 int hashIdx = line.IndexOf('#');
                 Document.ReplaceLine(row, line.Remove(hashIdx, 1));
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4c05951-9d08-4716-a4b0-8ca65f00237b)

Toggling here shouldn't destroy the timestamp. It's a nice property to have `Ctrl-K Ctrl-K` end up with the original text.