### PR TITLE
toggle comment: fix detection of actual comment vs input

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2101,10 +2101,7 @@ public sealed class Editor : Drawable {
             var lineTrimmed = line.TrimStart();
 
             if (lineTrimmed.StartsWith('#')) {
-                if (lineTrimmed.Length >= 2 && char.IsWhiteSpace(lineTrimmed[1]) ||
-                    lineTrimmed.StartsWith("#lvl_") ||
-                    TimestampRegex.IsMatch(lineTrimmed))
-                {
+                if(lineTrimmed.StartsWith("#lvl_") ||  TimestampRegex.IsMatch(lineTrimmed) || !ActionLine.TryParseStrict(lineTrimmed[1..], out _)) {
                     // Ignore comments and special labels
                     continue;
                 }


### PR DESCRIPTION
`#   7,U,X` is a commented action line so detecting `# ` is not sufficient to determine that the line is an actuall comment.