### PR TITLE
select word on double click

### DIFF
--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2699,6 +2699,32 @@ public sealed class Editor : Drawable {
         base.OnMouseMove(e);
     }
 
+    protected override void OnMouseDoubleClick(MouseEventArgs e) {
+        var position = Document.Caret;
+        string line = Document.Lines[position.Row];
+
+        int startIdx = position.Col;
+        int endIdx = position.Col;
+        while (startIdx > 0 && ShouldExpand(line[startIdx-1])) {
+            startIdx--;
+        }
+        while (endIdx < line.Length && ShouldExpand(line[endIdx])) {
+            endIdx++;
+        }
+
+        Document.Selection.Start = position with { Col = startIdx };
+        Document.Selection.End = position with { Col = endIdx };
+
+        e.Handled = true;
+        Recalc();
+        return;
+
+        bool ShouldExpand(char c) {
+            return !char.IsWhiteSpace(c) && (!char.IsPunctuation(c) || c is '*' or '_');
+        }
+    }
+
+
     protected override void OnMouseWheel(MouseEventArgs e) {
         // Adjust frame count
         if (e.Modifiers.HasFlag(Keys.Shift)) {

--- a/Studio/CelesteStudio/Editing/Editor.cs
+++ b/Studio/CelesteStudio/Editing/Editor.cs
@@ -2703,6 +2703,7 @@ public sealed class Editor : Drawable {
         var position = Document.Caret;
         string line = Document.Lines[position.Row];
 
+        // Select clicked word
         int startIdx = position.Col;
         int endIdx = position.Col;
         while (startIdx > 0 && ShouldExpand(line[startIdx-1])) {
@@ -2719,9 +2720,7 @@ public sealed class Editor : Drawable {
         Recalc();
         return;
 
-        bool ShouldExpand(char c) {
-            return !char.IsWhiteSpace(c) && (!char.IsPunctuation(c) || c is '*' or '_');
-        }
+        static bool ShouldExpand(char c) => !char.IsWhiteSpace(c) && (!char.IsPunctuation(c) || c is '*' or '_');
     }
 
 


### PR DESCRIPTION
I'm not entirely sure if `!char.IsWhiteSpace(c) && (!char.IsPunctuation(c) || c is '*' or '_')` is the best condition for boundaries for this use case but it seems to match most other editors. 

```perl
console load SecretSanta2024/0-Lobbies/3-Hard 1032 -72 # should / and - also continue expanding? probably not
```
